### PR TITLE
Update 'github cloud ' release manifest

### DIFF
--- a/manifests/github cloud .yaml
+++ b/manifests/github cloud .yaml
@@ -8,4 +8,4 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2


### PR DESCRIPTION
### Update 'github cloud ' release manifest

This PR updates the following release manifest:

**github cloud :**
- same alias → v4.0.2

