### PR TITLE
Update cloud manifest production github, woo staging manifest, main branch, main github, my manifest, one more manifest, some name for my manifest release manifests

### DIFF
--- a/manifests/cloud manifest production github.yaml
+++ b/manifests/cloud manifest production github.yaml
@@ -6,4 +6,4 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2

--- a/manifests/main branch.yaml
+++ b/manifests/main branch.yaml
@@ -21,4 +21,4 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2

--- a/manifests/main github.yaml
+++ b/manifests/main github.yaml
@@ -6,4 +6,4 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2

--- a/manifests/my manifest.yaml
+++ b/manifests/my manifest.yaml
@@ -13,6 +13,6 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2
   - uuid: de473d1a-081a-4806-b575-0b346fccaa38
     release: latest

--- a/manifests/one more manifest.yaml
+++ b/manifests/one more manifest.yaml
@@ -9,4 +9,4 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2

--- a/manifests/some name for my manifest.yaml
+++ b/manifests/some name for my manifest.yaml
@@ -27,6 +27,6 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2
   - uuid: de473d1a-081a-4806-b575-0b346fccaa38
     release: latest

--- a/manifests/woo staging manifest.yaml
+++ b/manifests/woo staging manifest.yaml
@@ -27,6 +27,6 @@ workflows:
   - uuid: 99ce804a-4f49-4d2d-855f-e8aef27f575d
     release: latest
   - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
-    release: latest
+    release: 4.0.2
   - uuid: de473d1a-081a-4806-b575-0b346fccaa38
     release: latest


### PR DESCRIPTION
### Update cloud manifest production github, woo staging manifest, main branch, main github, my manifest, one more manifest, some name for my manifest release manifests

This PR updates the following release manifests:

**cloud manifest production github:**
- same alias → v4.0.2

**woo staging manifest:**
- same alias → v4.0.2

**main branch:**
- same alias → v4.0.2

**main github:**
- same alias → v4.0.2

**my manifest:**
- same alias → v4.0.2

**one more manifest:**
- same alias → v4.0.2

**some name for my manifest:**
- same alias → v4.0.2

