### PR TITLE
Update 'github localhost' release manifest

### DIFF
--- a/manifests/github localhost.yaml
+++ b/manifests/github localhost.yaml
@@ -1,2 +1,5 @@
 version: 1.0.0
 name: github localhost
+workflows:
+  - uuid: 9cf9662e-9be6-45c3-9d53-afe49feec24b
+    release: 5.0.0


### PR DESCRIPTION
### Update 'github localhost' release manifest

This PR updates the following release manifest:

**github localhost:**
- same alias → v5.0.0

