### PR TITLE
Update 'docker main' release manifest

### DIFF
--- a/manifests/docker main.yaml
+++ b/manifests/docker main.yaml
@@ -4,7 +4,7 @@ apps:
   - uuid: 1581d6d6-66b7-11f1-9a45-53b1fe1d12f8
     release: latest
   - uuid: 183bd5d2-25ec-11f0-ad27-07bf802db1d4
-    release: 1.0.0
+    release: 1.0.1
   - uuid: 1f68d028-b989-11ef-816f-27ddfedb6603
     release: latest
   - uuid: 3c49479e-99b9-11ef-9ae2-a7c325fa25c4


### PR DESCRIPTION
### Update 'docker main' release manifest

This PR updates the following release manifest:

**docker main:**
- woo sisters payment → v1.0.1

