### PR TITLE
Update docker staging, docker main, main cloud githhub release manifests

### DIFF
--- a/manifests/docker main.yaml
+++ b/manifests/docker main.yaml
@@ -4,7 +4,7 @@ apps:
   - uuid: 1581d6d6-66b7-11f1-9a45-53b1fe1d12f8
     release: latest
   - uuid: 183bd5d2-25ec-11f0-ad27-07bf802db1d4
-    release: 1.0.1
+    release: latest
   - uuid: 1f68d028-b989-11ef-816f-27ddfedb6603
     release: latest
   - uuid: 3c49479e-99b9-11ef-9ae2-a7c325fa25c4

--- a/manifests/docker staging.yaml
+++ b/manifests/docker staging.yaml
@@ -4,7 +4,7 @@ apps:
   - uuid: 1581d6d6-66b7-11f1-9a45-53b1fe1d12f8
     release: latest
   - uuid: 183bd5d2-25ec-11f0-ad27-07bf802db1d4
-    release: 1.0.0
+    release: latest
   - uuid: 1f68d028-b989-11ef-816f-27ddfedb6603
     release: latest
   - uuid: 3c49479e-99b9-11ef-9ae2-a7c325fa25c4

--- a/manifests/main cloud githhub.yaml
+++ b/manifests/main cloud githhub.yaml
@@ -4,7 +4,7 @@ apps:
   - uuid: 1581d6d6-66b7-11f1-9a45-53b1fe1d12f8
     release: latest
   - uuid: 183bd5d2-25ec-11f0-ad27-07bf802db1d4
-    release: 1.0.0
+    release: latest
   - uuid: 1f68d028-b989-11ef-816f-27ddfedb6603
     release: latest
   - uuid: 3c49479e-99b9-11ef-9ae2-a7c325fa25c4


### PR DESCRIPTION
### Update docker staging, docker main, main cloud githhub release manifests

This PR updates the following release manifests:

**docker staging:**
- woo sisters payment → latest

**docker main:**
- woo sisters payment → latest

**main cloud githhub:**
- woo sisters payment → latest

